### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This is a service library for the DreamFactory platform containing a MemSQL data
 This is an add on to the DreamFactory Core library and requires the [df-core repository](http://github.com/dreamfactorysoftware/df-core).
 
 This code is governed by a commercial license. To use it, you must follow the [terms of use](http://dreamfactory.com/termsofuse), refer to the LICENSE file.
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -31,15 +31,18 @@
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
-  "repositories":      [
-    {
-      "type": "vcs",
-      "url":  "https://github.com/dreamfactorysoftware/df-mysqldb"
-    }
-  ],
   "require":     {
-    "dreamfactory/df-mysqldb": "~0.3",
-    "dreamfactory/df-sqldb": "~1.0"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-mysqldb": "~1.0",
+    "dreamfactory/df-sqldb": "~1.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {


### PR DESCRIPTION
## Summary

Composer-only upgrade of df-memsql to Laravel 13.7. df-memsql is a thin extension package over df-mysqldb / df-sqldb / Illuminate's MySQL primitives; no source changes were required.

## Changes

| Field | Before | After |
|---|---|---|
| `php` | (unspecified) | `^8.3` |
| `laravel/helpers` | (none) | `^1.8` |
| `dreamfactory/df-mysqldb` | `~0.3` | `~1.0` |
| `dreamfactory/df-sqldb` | `~1.0` | `~1.4` |
| `repositories` (VCS for df-mysqldb) | present | **dropped** (resolved via host app) |
| `require-dev` | (none) | `laravel/framework ^13.7`, `phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery ^1.6`, `nunomaduro/collision ^8.6` |

## Why no source changes?

All seven source files in `src/` are thin extensions:

| Class | Extends |
|---|---|
| `MemSqlConnection` | `Illuminate\Database\MySqlConnection` (still present in L13.7) |
| `MemSqlConnector` | `Illuminate\Database\Connectors\MySqlConnector` (still present) |
| `MemSqlGrammar` | `Illuminate\Database\Query\Grammars\MySqlGrammar` (still present) |
| `MemSqlSchema` | `DreamFactory\Core\SqlDb\Database\Schema\MySqlSchema` (df-sqldb) |
| `MemSqlDb` | `DreamFactory\Core\MySqlDb\Services\MySqlDb` (df-mysqldb) |
| `MemSqlDbConfig` | `DreamFactory\Core\MySqlDb\Models\MySqlDbConfig` (df-mysqldb) |
| `ServiceProvider` | `Illuminate\Support\ServiceProvider` (no change) |

No `Connection::select()`/`cursor()` overrides, no `DispatchesJobs`, no `CorsService`, no `getDates()` on `HasAttributes`, no PHPUnit-11 method-name typos, no test fixtures implementing `ConnectionInterface`. Nothing in df-memsql touches the L13 break surface.

## Validation

**Stage 1** — isolated install via path-repos (`df-core`, `df-system`, `df-database`, `df-sqldb`, `df-mysqldb`):

- `composer validate --strict`: clean
- `php -l` on all 7 src files: clean
- `composer install --no-dev` on Laravel 13.7.0: success
- Autoload smoke: 7/7 classes resolved, `array_get`/`camel_case`/`array_except` polyfills present

**Stage 2** — host app worktree (`shift-173254` of `dreamfactorysoftware/dreamfactory`) with the standard Wave 1/2 sibling-strip list (`df-mongo-logs`, `df-git`, `df-oauth`, `df-mcp-server`, `MongoDB\Laravel\MongoDBServiceProvider` commented):

- `composer install --no-dev`: 82 packages installed, Laravel 13.7.0 confirmed
- Autoload + reflection smoke: 7/7 classes load, full inheritance chain intact

## Coordination

This PR **depends on** df-mysqldb's Wave 2 L13 PR. df-mysqldb must be merged and tagged within the `~1.0` series before df-memsql can be released. Until then, host-app testing requires a path-repo to df-mysqldb's `shift/laravel-13` working tree (which already has its L13 deps in place but is uncommitted as of this writing).

## Test plan

- [x] `composer validate --strict`
- [x] `php -l` on all source files
- [x] Stage 1 isolated install (7/7 classes autoload)
- [x] Stage 2 host-app integration (Laravel 13.7.0, 7/7 classes, inheritance verified)
- [ ] Live MemSQL/SingleStore connection smoke (deferred — no test fixture in repo, requires Wave 2 sibling completion)
- [ ] Full host-app `php artisan test` (deferred — pending sibling Wave 2 completion)

Part of the 53-package Laravel 11 -> 13 upgrade campaign. Wave 0 (df-core) + Wave 1 (df-system, df-database, df-sqldb, df-user) shipped.